### PR TITLE
Add llama-server command logging and fix argument format

### DIFF
--- a/tests/llama_server_test_utils.py
+++ b/tests/llama_server_test_utils.py
@@ -20,7 +20,20 @@ def parse_comma_args(raw_args):
     if not raw_args:
         return []
     if "," in raw_args:
-        return [arg.strip() for arg in raw_args.split(",") if arg.strip()]
+        # Split by comma, then convert --flag=value to --flag value
+        result = []
+        for arg in raw_args.split(","):
+            arg = arg.strip()
+            if not arg:
+                continue
+            if "=" in arg:
+                # Convert --flag=value or -flag=value to separate args
+                flag, value = arg.split("=", 1)
+                result.append(flag)
+                result.append(value)
+            else:
+                result.append(arg)
+        return result
     return shlex.split(raw_args)
 
 
@@ -252,6 +265,7 @@ def start_llama_server(port=None, host=None, extra_args=None, ready_timeout_s=No
         cmd += ["--parallel", str(parallel)]
     cmd += extra_args
 
+    print(f"[llama-server] {' '.join(shlex.quote(str(arg)) for arg in cmd)}")
     process = subprocess.Popen(
         cmd,
         stdout=subprocess.DEVNULL,


### PR DESCRIPTION
- Log the actual `llama-server` command being executed for **easier debugging**
- Convert `--flag=value` format to `--flag value` format when parsing comma-separated args
- This helps debug issues with `additional-server-args` by showing the **exact command** that is running

## Screenshots of the changes

**Additional args**
<img width="1274" height="1064" alt="image" src="https://github.com/user-attachments/assets/8b0700c8-07d8-48c0-ae27-88fd95d1ad4e" />

**llama-server commands**
<img width="3000" height="520" alt="image" src="https://github.com/user-attachments/assets/b59bb2d1-96d3-4c1b-9387-f75891b2680d" />

**amdgpu_top**
<img width="2934" height="1618" alt="image" src="https://github.com/user-attachments/assets/28bbe595-f383-4aed-b2bb-54352813d463" />

